### PR TITLE
removed nav and footer because using wordpress forward and masking

### DIFF
--- a/yrci-university/app/page.tsx
+++ b/yrci-university/app/page.tsx
@@ -59,9 +59,9 @@ export default function App() {
 
   return (
     <>
-    <NavBar/>
+    {/* <NavBar/> */}
     <Home/>
-    <Footer/>
+    {/* <Footer/> */}
      {/* <Hero/>
      <SocialProof/>
      <WhyChooseUs/>


### PR DESCRIPTION
Enabled url forward and masking on Wordpress to mask the vercel url